### PR TITLE
Support for more services -- SageMaker Notebook and Gateway Endpoints (S3/Dynamo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ Terraform `>= 0.12.9` is required due to a bug fix related to empty sets with `f
 version `0.12.9` -- see the [Changelog here](https://github.com/hashicorp/terraform/blob/v0.12/CHANGELOG.md#0129-september-17-2019).
 The original [bug was reported as issue #22281](https://github.com/hashicorp/terraform/issues/22281).
 
+## Updating documentation
+Portions of this module's README.md, and those in its `tests` directory, are generated automatically. To update the sections inside `BEGIN TFDOCS` and `END TFDOCS` run the following:
+
+```sh
+docker build -t terraform-aws-tardigrade-vpc-endpoints:latest .
+docker run --rm -ti -v "$(pwd):/ci-harness/my-project" terraform-aws-tardigrade-vpc-endpoints:latest docs/generate
+```
+
+Then commit the updated files.
+
 <!-- BEGIN TFDOCS -->
 ## Providers
 
@@ -30,8 +40,8 @@ The original [bug was reported as issue #22281](https://github.com/hashicorp/ter
 
 | Name | Description |
 |------|-------------|
-| vpc\_endpoint\_interface\_services | n/a |
 | vpc\_endpoint\_gateway\_services | n/a |
+| vpc\_endpoint\_interface\_services | n/a |
 | vpc\_endpoint\_sgs | n/a |
 
 <!-- END TFDOCS -->

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Terraform module to create VPC Endpoints
 
+## Terraform version requirements
+Terraform `>= 0.12.9` is required due to a bug fix related to empty sets with `for_each`. The fix was included in
+version `0.12.9` -- see the [Changelog here](https://github.com/hashicorp/terraform/blob/v0.12/CHANGELOG.md#0129-september-17-2019).
+The original [bug was reported as issue #22281](https://github.com/hashicorp/terraform/issues/22281).
 
 <!-- BEGIN TFDOCS -->
 ## Providers

--- a/README.md
+++ b/README.md
@@ -14,19 +14,20 @@ Terraform module to create VPC Endpoints
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
-| sg\_egress\_rules | Egress rules for the vpc endpoint sg(s). Set to empty list to disable default rules. | `list` | n/a | yes |
-| sg\_ingress\_rules | Ingress rules for the vpc endpoint sg(s). Set to empty list to disable default rules. | `list` | n/a | yes |
-| create\_sg\_per\_endpoint | toggle to create a sg for each vpc endpoint. Defaults to using just one for all endpoints. | `bool` | `false` | no |
-| create\_vpc\_endpoints | toggle to create vpc endpoints | `bool` | `true` | no |
-| subnet\_ids | target subnet ids | `list(string)` | `[]` | no |
-| tags | A map of tags to add to the VPC endpoint SG | `map(string)` | `{}` | no |
-| vpc\_endpoint\_services | List of aws endpoint service names that are used to create VPC Interface endpoints. See https://docs.aws.amazon.com/general/latest/gr/rande.html for full list. | `list(string)` | `[]` | no |
+| sg\_egress\_rules | Egress rules for the VPC Endpoint SecurityGroup(s). Set to empty list to disable default rules. | `list` | n/a | yes |
+| sg\_ingress\_rules | Ingress rules for the VPC Endpoint SecurityGroup(s). Set to empty list to disable default rules. | `list` | n/a | yes |
+| create\_sg\_per\_endpoint | Toggle to create a SecurityGroup for each VPC Endpoint. Defaults to using just one for all Interface Endpoints. Note that Gateway Endpoints don't support SecurityGroups. | `bool` | `false` | no |
+| create\_vpc\_endpoints | Toggle to create VPC Endpoints. | `bool` | `true` | no |
+| subnet\_ids | Target Subnet ids. | `list(string)` | `[]` | no |
+| tags | A map of tags to add to the VPC Endpoint and to the SecurityGroup(s). | `map(string)` | `{}` | no |
+| vpc\_endpoint\_services | List of AWS Endpoint service names that are used to create VPC Interface Endpoints. Both Gateway and Interface Endpoints are supported. See https://docs.aws.amazon.com/general/latest/gr/rande.html for full list. | `list(string)` | `[]` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | vpc\_endpoint\_interface\_services | n/a |
+| vpc\_endpoint\_gateway\_services | n/a |
 | vpc\_endpoint\_sgs | n/a |
 
 <!-- END TFDOCS -->

--- a/README.md
+++ b/README.md
@@ -11,8 +11,17 @@ The original [bug was reported as issue #22281](https://github.com/hashicorp/ter
 Portions of this module's README.md, and those in its `tests` directory, are generated automatically. To update the sections inside `BEGIN TFDOCS` and `END TFDOCS` run the following:
 
 ```sh
-docker build -t terraform-aws-tardigrade-vpc-endpoints:latest .
-docker run --rm -ti -v "$(pwd):/ci-harness/my-project" terraform-aws-tardigrade-vpc-endpoints:latest docs/generate
+## This will run terraform-docs in the docker container, which of
+## course requires that you have docker...
+# The 'init' target is a one time task... it simply clones a "ci" repository to access shared make targets
+make init
+make docker/run target=docs/generate
+
+## Or
+## This will install terraform-docs to your local system, may not
+## be desirable for you. And may not work if the make target does
+## not account for your OS
+make docs/generate
 ```
 
 Then commit the updated files.

--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ locals {
   vpc_cidr = join("", data.aws_vpc.selected.*.cidr_block)
 
   # Split Endpoints by their type
-  gateway_endpoints = toset([for e in data.aws_vpc_endpoint_service.this : e.service_name if e.service_type == "Gateway"])
+  gateway_endpoints   = toset([for e in data.aws_vpc_endpoint_service.this : e.service_name if e.service_type == "Gateway"])
   interface_endpoints = toset([for e in data.aws_vpc_endpoint_service.this : e.service_name if e.service_type == "Interface"])
 
   # Only Interface Endpoints support SGs

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,3 +5,7 @@ output "vpc_endpoint_sgs" {
 output "vpc_endpoint_interface_services" {
   value = aws_vpc_endpoint.interface_services
 }
+
+output "vpc_endpoint_gateway_services" {
+  value = aws_vpc_endpoint.gateway_services
+}

--- a/tests/config_endpoint/versions.tf
+++ b/tests/config_endpoint/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.9"
 }

--- a/tests/fully_qualified_name_endpoint/README.md
+++ b/tests/fully_qualified_name_endpoint/README.md
@@ -1,0 +1,19 @@
+# Fully Qualified Name Endpoint Test
+
+
+<!-- BEGIN TFDOCS -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| random | n/a |
+
+## Inputs
+
+No input.
+
+## Outputs
+
+No output.
+
+<!-- END TFDOCS -->

--- a/tests/fully_qualified_name_endpoint/main.tf
+++ b/tests/fully_qualified_name_endpoint/main.tf
@@ -1,0 +1,35 @@
+provider aws {
+  region = "us-east-1"
+}
+
+resource "random_string" "this" {
+  length  = 6
+  upper   = false
+  special = false
+  number  = false
+}
+
+module "vpc" {
+  source = "github.com/terraform-aws-modules/terraform-aws-vpc?ref=v2.15.0"
+  providers = {
+    aws = aws
+  }
+
+  name                 = "tardigrade-vpc-endpoints-${random_string.this.result}"
+  cidr                 = "10.0.0.0/16"
+  azs                  = ["us-east-1a", "us-east-1b"]
+  private_subnets      = ["10.0.1.0/24", "10.0.2.0/24"]
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+}
+
+module "fully_qualified_name_endpoint" {
+  source = "../../"
+  providers = {
+    aws = aws
+  }
+
+  create_vpc_endpoints  = true
+  vpc_endpoint_services = ["aws.sagemaker.us-east-1.notebook"]
+  subnet_ids            = module.vpc.private_subnets
+}

--- a/tests/fully_qualified_name_endpoint/versions.tf
+++ b/tests/fully_qualified_name_endpoint/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/tests/fully_qualified_name_endpoint/versions.tf
+++ b/tests/fully_qualified_name_endpoint/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.9"
 }

--- a/tests/gateway_type_endpoint/README.md
+++ b/tests/gateway_type_endpoint/README.md
@@ -1,0 +1,19 @@
+# Gateway Type Endpoint Test
+
+
+<!-- BEGIN TFDOCS -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| random | n/a |
+
+## Inputs
+
+No input.
+
+## Outputs
+
+No output.
+
+<!-- END TFDOCS -->

--- a/tests/gateway_type_endpoint/main.tf
+++ b/tests/gateway_type_endpoint/main.tf
@@ -1,0 +1,35 @@
+provider aws {
+  region = "us-east-1"
+}
+
+resource "random_string" "this" {
+  length  = 6
+  upper   = false
+  special = false
+  number  = false
+}
+
+module "vpc" {
+  source = "github.com/terraform-aws-modules/terraform-aws-vpc?ref=v2.15.0"
+  providers = {
+    aws = aws
+  }
+
+  name                 = "tardigrade-vpc-endpoints-${random_string.this.result}"
+  cidr                 = "10.0.0.0/16"
+  azs                  = ["us-east-1a", "us-east-1b"]
+  private_subnets      = ["10.0.1.0/24", "10.0.2.0/24"]
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+}
+
+module "gateway_type_endpoint" {
+  source = "../../"
+  providers = {
+    aws = aws
+  }
+
+  create_vpc_endpoints  = true
+  vpc_endpoint_services = ["s3"]
+  subnet_ids            = module.vpc.private_subnets
+}

--- a/tests/gateway_type_endpoint/versions.tf
+++ b/tests/gateway_type_endpoint/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/tests/gateway_type_endpoint/versions.tf
+++ b/tests/gateway_type_endpoint/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.9"
 }

--- a/tests/multiple_endpoints/versions.tf
+++ b/tests/multiple_endpoints/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.9"
 }

--- a/tests/no_create/versions.tf
+++ b/tests/no_create/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.9"
 }

--- a/tests/no_endpoints/versions.tf
+++ b/tests/no_endpoints/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.9"
 }

--- a/tests/sg_per_endpoint/README.md
+++ b/tests/sg_per_endpoint/README.md
@@ -1,0 +1,19 @@
+# SG Per Endpoint Test
+
+
+<!-- BEGIN TFDOCS -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| random | n/a |
+
+## Inputs
+
+No input.
+
+## Outputs
+
+No output.
+
+<!-- END TFDOCS -->

--- a/tests/sg_per_endpoint/main.tf
+++ b/tests/sg_per_endpoint/main.tf
@@ -29,8 +29,8 @@ module "sg_per_endpoint" {
     aws = aws
   }
 
-  create_vpc_endpoints  = true
-  vpc_endpoint_services = ["s3", "sns"]
-  subnet_ids            = module.vpc.private_subnets
+  create_vpc_endpoints   = true
+  vpc_endpoint_services  = ["s3", "sns"]
+  subnet_ids             = module.vpc.private_subnets
   create_sg_per_endpoint = true
 }

--- a/tests/sg_per_endpoint/main.tf
+++ b/tests/sg_per_endpoint/main.tf
@@ -1,0 +1,36 @@
+provider aws {
+  region = "us-east-1"
+}
+
+resource "random_string" "this" {
+  length  = 6
+  upper   = false
+  special = false
+  number  = false
+}
+
+module "vpc" {
+  source = "github.com/terraform-aws-modules/terraform-aws-vpc?ref=v2.15.0"
+  providers = {
+    aws = aws
+  }
+
+  name                 = "tardigrade-vpc-endpoints-${random_string.this.result}"
+  cidr                 = "10.0.0.0/16"
+  azs                  = ["us-east-1a", "us-east-1b"]
+  private_subnets      = ["10.0.1.0/24", "10.0.2.0/24"]
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+}
+
+module "sg_per_endpoint" {
+  source = "../../"
+  providers = {
+    aws = aws
+  }
+
+  create_vpc_endpoints  = true
+  vpc_endpoint_services = ["s3", "sns"]
+  subnet_ids            = module.vpc.private_subnets
+  create_sg_per_endpoint = true
+}

--- a/tests/sg_per_endpoint/versions.tf
+++ b/tests/sg_per_endpoint/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/tests/sg_per_endpoint/versions.tf
+++ b/tests/sg_per_endpoint/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.9"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,41 +1,41 @@
 variable "create_sg_per_endpoint" {
-  description = "toggle to create a sg for each vpc endpoint. Defaults to using just one for all endpoints."
+  description = "Toggle to create a SecurityGroup for each VPC Endpoint. Defaults to using just one for all Interface Endpoints. Note that Gateway Endpoints don't support SecurityGroups."
   type        = bool
   default     = false
 }
 
 variable "create_vpc_endpoints" {
-  description = "toggle to create vpc endpoints"
+  description = "Toggle to create VPC Endpoints."
   type        = bool
   default     = true
 }
 
 variable "sg_egress_rules" {
-  description = "Egress rules for the vpc endpoint sg(s). Set to empty list to disable default rules."
+  description = "Egress rules for the VPC Endpoint SecurityGroup(s). Set to empty list to disable default rules."
   type        = list
   default     = null
 }
 
 variable "sg_ingress_rules" {
-  description = "Ingress rules for the vpc endpoint sg(s). Set to empty list to disable default rules."
+  description = "Ingress rules for the VPC Endpoint SecurityGroup(s). Set to empty list to disable default rules."
   type        = list
   default     = null
 }
 
 variable "subnet_ids" {
   type        = list(string)
-  description = "target subnet ids"
+  description = "Target Subnet ids."
   default     = []
 }
 
 variable "vpc_endpoint_services" {
   type        = list(string)
-  description = "List of aws endpoint service names that are used to create VPC Interface endpoints. See https://docs.aws.amazon.com/general/latest/gr/rande.html for full list."
+  description = "List of AWS Endpoint service names that are used to create VPC Interface Endpoints. Both Gateway and Interface Endpoints are supported. See https://docs.aws.amazon.com/general/latest/gr/rande.html for full list."
   default     = []
 }
 
 variable "tags" {
-  description = "A map of tags to add to the VPC endpoint SG"
+  description = "A map of tags to add to the VPC Endpoint and to the SecurityGroup(s)."
   type        = map(string)
   default     = {}
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.9"
 }


### PR DESCRIPTION
Fixes #49.

During a recent project my team @Ibotta found a couple of things that we wanted to adjust for our use case.

First, I found that the module doesn't support SageMaker Notebook because this service uses a "non-standard" fully qualified service name. It also doesn't seem to have a common name; it can only be referenced by the full name (ex: `aws.sagemaker.us-east-1.notebook`).

Second, I wanted to be able to use the module for both `Interface` and `Gateway` type Endpoints.

Lastly, I wanted to use for_each on the endpoints to avoid list sorting issues as we add/remove endpoints.

