### PR TITLE
Fix custom SecurityGroup rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,16 @@
 
 Terraform module to create VPC Endpoints
 
+## Default Security Group rules
+Please be aware that the default Security Groups attached to Endpoints allow Ingress and Egress from anywhere
+(`0.0.0.0/0`). It is advised that users adjust these to fit their desired security posture. We recommend a minimum
+of restricting Ingress to the VPC `cidr_block`.
+
 ## Terraform version requirements
 Terraform `>= 0.12.9` is required due to a bug fix related to empty sets with `for_each`. The fix was included in
 version `0.12.9` -- see the [Changelog here](https://github.com/hashicorp/terraform/blob/v0.12/CHANGELOG.md#0129-september-17-2019).
 The original [bug was reported as issue #22281](https://github.com/hashicorp/terraform/issues/22281).
+
 
 ## Updating documentation
 Portions of this module's README.md, and those in its `tests` directory, are generated automatically. To update the sections inside `BEGIN TFDOCS` and `END TFDOCS` run the following:
@@ -45,8 +51,8 @@ Then commit the updated files.
 |------|-------------|------|---------|:--------:|
 | create\_sg\_per\_endpoint | Toggle to create a SecurityGroup for each VPC Endpoint. Defaults to using just one for all Interface Endpoints. Note that Gateway Endpoints don't support SecurityGroups. | `bool` | `false` | no |
 | create\_vpc\_endpoints | Toggle to create VPC Endpoints. | `bool` | `true` | no |
-| sg\_egress\_rules | Egress rules for the VPC Endpoint SecurityGroup(s). Set to empty list to disable default rules. | <pre>list(object({<br>    description      = string<br>    prefix_list_ids  = list(string)<br>    from_port        = number<br>    to_port          = number<br>    protocol         = string<br>    cidr_blocks      = list(string)<br>    ipv6_cidr_blocks = list(string)<br>    security_groups  = list(string)<br>  }))</pre> | `null` | no |
-| sg\_ingress\_rules | Ingress rules for the VPC Endpoint SecurityGroup(s). Set to empty list to disable default rules. | <pre>list(object({<br>    description      = string<br>    prefix_list_ids  = list(string)<br>    from_port        = number<br>    to_port          = number<br>    protocol         = string<br>    cidr_blocks      = list(string)<br>    ipv6_cidr_blocks = list(string)<br>    security_groups  = list(string)<br>  }))</pre> | `null` | no |
+| sg\_egress\_rules | Egress rules for the VPC Endpoint SecurityGroup(s). Set to empty list to disable default rules. | <pre>list(object({<br>    description      = string<br>    prefix_list_ids  = list(string)<br>    from_port        = number<br>    to_port          = number<br>    protocol         = string<br>    cidr_blocks      = list(string)<br>    ipv6_cidr_blocks = list(string)<br>    security_groups  = list(string)<br>  }))</pre> | <pre>[<br>  {<br>    "cidr_blocks": [<br>      "0.0.0.0/0"<br>    ],<br>    "description": null,<br>    "from_port": 0,<br>    "ipv6_cidr_blocks": null,<br>    "prefix_list_ids": null,<br>    "protocol": "-1",<br>    "security_groups": null,<br>    "to_port": 0<br>  }<br>]</pre> | no |
+| sg\_ingress\_rules | Ingress rules for the VPC Endpoint SecurityGroup(s). Set to empty list to disable default rules. | <pre>list(object({<br>    description      = string<br>    prefix_list_ids  = list(string)<br>    from_port        = number<br>    to_port          = number<br>    protocol         = string<br>    cidr_blocks      = list(string)<br>    ipv6_cidr_blocks = list(string)<br>    security_groups  = list(string)<br>  }))</pre> | <pre>[<br>  {<br>    "cidr_blocks": [<br>      "0.0.0.0/0"<br>    ],<br>    "description": null,<br>    "from_port": 0,<br>    "ipv6_cidr_blocks": null,<br>    "prefix_list_ids": null,<br>    "protocol": "-1",<br>    "security_groups": null,<br>    "to_port": 0<br>  }<br>]</pre> | no |
 | subnet\_ids | Target Subnet ids. | `list(string)` | `[]` | no |
 | tags | A map of tags to add to the VPC Endpoint and to the SecurityGroup(s). | `map(string)` | `{}` | no |
 | vpc\_endpoint\_services | List of AWS Endpoint service names that are used to create VPC Interface Endpoints. Both Gateway and Interface Endpoints are supported. See https://docs.aws.amazon.com/general/latest/gr/rande.html for full list. | `list(string)` | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Then commit the updated files.
 |------|-------------|------|---------|:--------:|
 | create\_sg\_per\_endpoint | Toggle to create a SecurityGroup for each VPC Endpoint. Defaults to using just one for all Interface Endpoints. Note that Gateway Endpoints don't support SecurityGroups. | `bool` | `false` | no |
 | create\_vpc\_endpoints | Toggle to create VPC Endpoints. | `bool` | `true` | no |
-| sg\_egress\_rules | Egress rules for the VPC Endpoint SecurityGroup(s). Set to empty list to disable default rules. | `list` | `null` | no |
-| sg\_ingress\_rules | Ingress rules for the VPC Endpoint SecurityGroup(s). Set to empty list to disable default rules. | `list` | `null` | no |
+| sg\_egress\_rules | Egress rules for the VPC Endpoint SecurityGroup(s). Set to empty list to disable default rules. | <pre>list(object({<br>    description      = string<br>    prefix_list_ids  = list(string)<br>    from_port        = number<br>    to_port          = number<br>    protocol         = string<br>    cidr_blocks      = list(string)<br>    ipv6_cidr_blocks = list(string)<br>    security_groups  = list(string)<br>  }))</pre> | `null` | no |
+| sg\_ingress\_rules | Ingress rules for the VPC Endpoint SecurityGroup(s). Set to empty list to disable default rules. | <pre>list(object({<br>    description      = string<br>    prefix_list_ids  = list(string)<br>    from_port        = number<br>    to_port          = number<br>    protocol         = string<br>    cidr_blocks      = list(string)<br>    ipv6_cidr_blocks = list(string)<br>    security_groups  = list(string)<br>  }))</pre> | `null` | no |
 | subnet\_ids | Target Subnet ids. | `list(string)` | `[]` | no |
 | tags | A map of tags to add to the VPC Endpoint and to the SecurityGroup(s). | `map(string)` | `{}` | no |
 | vpc\_endpoint\_services | List of AWS Endpoint service names that are used to create VPC Interface Endpoints. Both Gateway and Interface Endpoints are supported. See https://docs.aws.amazon.com/general/latest/gr/rande.html for full list. | `list(string)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -26,16 +26,24 @@ data "aws_vpc" "selected" {
 
 locals {
   sg_egress_rules_default = list({
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    description      = null
+    prefix_list_ids  = null
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = null
+    security_groups  = null
   })
   sg_ingress_rules_default = list({
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = [local.vpc_cidr]
+    description      = null
+    prefix_list_ids  = null
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = [local.vpc_cidr]
+    ipv6_cidr_blocks = null
+    security_groups  = null
   })
   vpc_id   = join("", data.aws_subnet.selected.*.vpc_id)
   vpc_cidr = join("", data.aws_vpc.selected.*.cidr_block)
@@ -59,9 +67,9 @@ resource "aws_security_group" "this" {
     content {
       description      = lookup(egress.value, "description", null)
       prefix_list_ids  = lookup(egress.value, "prefix_list_ids", null)
-      from_port        = lookup(egress.value, "from_port", null)
-      to_port          = lookup(egress.value, "to_port", null)
-      protocol         = lookup(egress.value, "protocol", null)
+      from_port        = lookup(egress.value, "from_port")
+      to_port          = lookup(egress.value, "to_port")
+      protocol         = lookup(egress.value, "protocol")
       cidr_blocks      = lookup(egress.value, "cidr_blocks", null)
       ipv6_cidr_blocks = lookup(egress.value, "ipv6_cidr_blocks", null)
       security_groups  = lookup(egress.value, "security_groups", null)
@@ -73,9 +81,9 @@ resource "aws_security_group" "this" {
     content {
       description      = lookup(ingress.value, "description", null)
       prefix_list_ids  = lookup(ingress.value, "prefix_list_ids", null)
-      from_port        = lookup(ingress.value, "from_port", null)
-      to_port          = lookup(ingress.value, "to_port", null)
-      protocol         = lookup(ingress.value, "protocol", null)
+      from_port        = lookup(ingress.value, "from_port")
+      to_port          = lookup(ingress.value, "to_port")
+      protocol         = lookup(ingress.value, "protocol")
       cidr_blocks      = lookup(ingress.value, "cidr_blocks", null)
       ipv6_cidr_blocks = lookup(ingress.value, "ipv6_cidr_blocks", null)
       security_groups  = lookup(ingress.value, "security_groups", null)

--- a/main.tf
+++ b/main.tf
@@ -25,26 +25,6 @@ data "aws_vpc" "selected" {
 }
 
 locals {
-  sg_egress_rules_default = list({
-    description      = null
-    prefix_list_ids  = null
-    from_port        = 0
-    to_port          = 0
-    protocol         = "-1"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = null
-    security_groups  = null
-  })
-  sg_ingress_rules_default = list({
-    description      = null
-    prefix_list_ids  = null
-    from_port        = 0
-    to_port          = 0
-    protocol         = "-1"
-    cidr_blocks      = [local.vpc_cidr]
-    ipv6_cidr_blocks = null
-    security_groups  = null
-  })
   vpc_id   = join("", data.aws_subnet.selected.*.vpc_id)
   vpc_cidr = join("", data.aws_vpc.selected.*.cidr_block)
 
@@ -63,7 +43,7 @@ resource "aws_security_group" "this" {
   vpc_id      = local.vpc_id
 
   dynamic "egress" {
-    for_each = var.sg_egress_rules != null ? var.sg_egress_rules : local.sg_egress_rules_default
+    for_each = var.sg_egress_rules
     content {
       description      = egress.value["description"]
       prefix_list_ids  = egress.value["prefix_list_ids"]
@@ -77,7 +57,7 @@ resource "aws_security_group" "this" {
   }
 
   dynamic "ingress" {
-    for_each = var.sg_ingress_rules != null ? var.sg_ingress_rules : local.sg_ingress_rules_default
+    for_each = var.sg_ingress_rules
     content {
       description      = ingress.value["description"]
       prefix_list_ids  = ingress.value["prefix_list_ids"]

--- a/main.tf
+++ b/main.tf
@@ -65,28 +65,28 @@ resource "aws_security_group" "this" {
   dynamic "egress" {
     for_each = var.sg_egress_rules != null ? var.sg_egress_rules : local.sg_egress_rules_default
     content {
-      description      = lookup(egress.value, "description", null)
-      prefix_list_ids  = lookup(egress.value, "prefix_list_ids", null)
-      from_port        = lookup(egress.value, "from_port")
-      to_port          = lookup(egress.value, "to_port")
-      protocol         = lookup(egress.value, "protocol")
-      cidr_blocks      = lookup(egress.value, "cidr_blocks", null)
-      ipv6_cidr_blocks = lookup(egress.value, "ipv6_cidr_blocks", null)
-      security_groups  = lookup(egress.value, "security_groups", null)
+      description      = egress.value["description"]
+      prefix_list_ids  = egress.value["prefix_list_ids"]
+      from_port        = egress.value["from_port"]
+      to_port          = egress.value["to_port"]
+      protocol         = egress.value["protocol"]
+      cidr_blocks      = egress.value["cidr_blocks"]
+      ipv6_cidr_blocks = egress.value["ipv6_cidr_blocks"]
+      security_groups  = egress.value["security_groups"]
     }
   }
 
   dynamic "ingress" {
     for_each = var.sg_ingress_rules != null ? var.sg_ingress_rules : local.sg_ingress_rules_default
     content {
-      description      = lookup(ingress.value, "description", null)
-      prefix_list_ids  = lookup(ingress.value, "prefix_list_ids", null)
-      from_port        = lookup(ingress.value, "from_port")
-      to_port          = lookup(ingress.value, "to_port")
-      protocol         = lookup(ingress.value, "protocol")
-      cidr_blocks      = lookup(ingress.value, "cidr_blocks", null)
-      ipv6_cidr_blocks = lookup(ingress.value, "ipv6_cidr_blocks", null)
-      security_groups  = lookup(ingress.value, "security_groups", null)
+      description      = ingress.value["description"]
+      prefix_list_ids  = ingress.value["prefix_list_ids"]
+      from_port        = ingress.value["from_port"]
+      to_port          = ingress.value["to_port"]
+      protocol         = ingress.value["protocol"]
+      cidr_blocks      = ingress.value["cidr_blocks"]
+      ipv6_cidr_blocks = ingress.value["ipv6_cidr_blocks"]
+      security_groups  = ingress.value["security_groups"]
     }
   }
 

--- a/tests/custom_sg_rules/main.tf
+++ b/tests/custom_sg_rules/main.tf
@@ -50,5 +50,5 @@ module "custom_sg_rules" {
   create_vpc_endpoints  = true
   vpc_endpoint_services = ["config"]
   subnet_ids            = module.vpc.private_subnets
-  sg_egress_rules       = local.sg_ingress_rules
+  sg_ingress_rules      = local.sg_ingress_rules
 }

--- a/tests/custom_sg_rules/main.tf
+++ b/tests/custom_sg_rules/main.tf
@@ -26,6 +26,8 @@ module "vpc" {
 locals {
   sg_ingress_rules = [
     {
+      description     = null
+      prefix_list_ids = null
       from_port       = 0
       to_port         = 0
       protocol        = "-1"
@@ -33,6 +35,8 @@ locals {
         module.vpc.vpc_cidr_block,
         "10.11.22.0/24"
       ]
+      ipv6_cidr_blocks = null
+      security_groups  = null
     }
   ]
 }

--- a/tests/custom_sg_rules/main.tf
+++ b/tests/custom_sg_rules/main.tf
@@ -1,0 +1,50 @@
+provider aws {
+  region = "us-east-1"
+}
+
+resource "random_string" "this" {
+  length  = 6
+  upper   = false
+  special = false
+  number  = false
+}
+
+module "vpc" {
+  source = "github.com/terraform-aws-modules/terraform-aws-vpc?ref=v2.15.0"
+  providers = {
+    aws = aws
+  }
+
+  name                 = "tardigrade-vpc-endpoints-${random_string.this.result}"
+  cidr                 = "10.0.0.0/16"
+  azs                  = ["us-east-1a", "us-east-1b"]
+  private_subnets      = ["10.0.1.0/24", "10.0.2.0/24"]
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+}
+
+locals {
+  sg_ingress_rules = [
+    {
+      from_port       = 0
+      to_port         = 0
+      protocol        = "-1"
+      cidr_blocks = [
+        module.vpc.vpc_cidr_block,
+        "10.11.22.0/24"
+      ]
+    }
+  ]
+}
+
+module "custom_sg_rules" {
+  source = "../../"
+  providers = {
+    aws = aws
+  }
+
+  create_vpc_endpoints  = true
+  vpc_endpoint_services = ["config"]
+  subnet_ids            = module.vpc.private_subnets
+  sg_egress_rules       = local.sg_ingress_rules
+}

--- a/tests/custom_sg_rules/versions.tf
+++ b/tests/custom_sg_rules/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12.9"
+}

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -353,6 +353,7 @@ golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586 h1:7KByu05hhLed2MO29w7p1X
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200109152110-61a87790db17 h1:nVJ3guKA9qdkEQ3TUdXI9QSINo2CUPM/cySEvw2w8I0=
 golang.org/x/crypto v0.0.0-20200109152110-61a87790db17/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -395,6 +396,7 @@ golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7 h1:fHDIZ2oxGnUZRN6WgWFCbYBjH
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 h1:efeOvDhwQ29Dj3SdAV/MJf8oukgn+8D8WgaCaRMchF8=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -520,6 +522,7 @@ gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bl
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/variables.tf
+++ b/variables.tf
@@ -22,7 +22,16 @@ variable "sg_egress_rules" {
     ipv6_cidr_blocks = list(string)
     security_groups  = list(string)
   }))
-  default = null
+  default = [{
+    description      = null
+    prefix_list_ids  = null
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = null
+    security_groups  = null
+  }]
 }
 
 variable "sg_ingress_rules" {
@@ -37,7 +46,16 @@ variable "sg_ingress_rules" {
     ipv6_cidr_blocks = list(string)
     security_groups  = list(string)
   }))
-  default = null
+  default = [{
+    description      = null
+    prefix_list_ids  = null
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = null
+    security_groups  = null
+  }]
 }
 
 variable "subnet_ids" {

--- a/variables.tf
+++ b/variables.tf
@@ -12,14 +12,32 @@ variable "create_vpc_endpoints" {
 
 variable "sg_egress_rules" {
   description = "Egress rules for the VPC Endpoint SecurityGroup(s). Set to empty list to disable default rules."
-  type        = list
-  default     = null
+  type = list(object({
+    description      = string
+    prefix_list_ids  = list(string)
+    from_port        = number
+    to_port          = number
+    protocol         = string
+    cidr_blocks      = list(string)
+    ipv6_cidr_blocks = list(string)
+    security_groups  = list(string)
+  }))
+  default = null
 }
 
 variable "sg_ingress_rules" {
   description = "Ingress rules for the VPC Endpoint SecurityGroup(s). Set to empty list to disable default rules."
-  type        = list
-  default     = null
+  type = list(object({
+    description      = string
+    prefix_list_ids  = list(string)
+    from_port        = number
+    to_port          = number
+    protocol         = string
+    cidr_blocks      = list(string)
+    ipv6_cidr_blocks = list(string)
+    security_groups  = list(string)
+  }))
+  default = null
 }
 
 variable "subnet_ids" {


### PR DESCRIPTION
I found I needed to adjust the default Security Group rules but when I tried to pass in my custom settings Terraform produced an error about mismatching types. Unfortunately it prints the "simple" form of the type so the error is obtuse.

I added a test which reliably produces the following error:

```
Error: Inconsistent conditional result types

  on ../../main.tf line 58, in resource "aws_security_group" "this":
  58:     for_each = var.sg_egress_rules != null ? var.sg_egress_rules : local.sg_egress_rules_default
    |----------------
    | local.sg_egress_rules_default is list of object with 1 element
    | var.sg_egress_rules is list of object with 1 element

The true and false result expressions must have consistent types. The given
expressions are list of object and list of object, respectively.
```

After reproduction I created a fix and updated the test.

In order for Terraform to properly deal with the conditional which handles default vs. custom rules it must be given the same complex type definition for both outcomes of the conditional. Since the _module_ includes some optional attributes for the `aws_security_group` resource the _user_ of the module must also pass in those attributes. Unfortunately there is no way to set a partial default on a complex type so a user will need to provide `null` values for any attribute they don't want to specify.

You can see an example usage in the test.

I tested against TF `0.12.9` (as it is the required minimum version) and also `0.12.24` (as it is the latest release).