### PR TITLE
Fix SG update due to description change

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -64,6 +64,10 @@ resource "aws_security_group" "this" {
   }
 
   tags = var.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_vpc_endpoint" "interface_services" {


### PR DESCRIPTION
bc90af9412 introduced a change to remove a data source and simplify the SG description. Unfortunately the `description` field on SGs is immutable and thus requires a replacement.

This PR utilizes the [`create_before_destroy` lifecycle policy](https://www.terraform.io/docs/configuration/resources.html#create_before_destroy) to force terraform into:
1. creating the new SG
1. updating the Endpoints
1. deleting the old SG

Without this update the following error is produced:
```
Error: Error deleting security group: DependencyViolation: resource sg-123456abcdef has a dependent object
```