### PR TITLE
Associate Route Tables with Gateway Endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ make mockstack/clean
 | Name | Type |
 |------|------|
 | [aws_region.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [aws_route_table.gateway_tables](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route_table) | data source |
 | [aws_subnet.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 | [aws_vpc_endpoint_service.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc_endpoint_service) | data source |
 
@@ -75,7 +76,7 @@ make mockstack/clean
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Target Subnet IDs for "Interface" services. Also used to resolve the `vpc_id` for "Gateway" services | `list(string)` | n/a | yes |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Target Subnet IDs for "Interface" services. Also used to resolve the `vpc_id` and route\_table\_ids for "Gateway" services | `list(string)` | n/a | yes |
 | <a name="input_vpc_endpoint_services"></a> [vpc\_endpoint\_services](#input\_vpc\_endpoint\_services) | List of AWS Endpoint service names and types. Both Gateway and Interface Endpoints are supported. See https://docs.aws.amazon.com/general/latest/gr/rande.html for full list. | <pre>list(object({<br>    name = string<br>    type = string<br>  }))</pre> | n/a | yes |
 | <a name="input_create_sg_per_endpoint"></a> [create\_sg\_per\_endpoint](#input\_create\_sg\_per\_endpoint) | Toggle to create a SecurityGroup for each VPC Endpoint. Defaults to using just one for all Interface Endpoints. Note that Gateway Endpoints don't support SecurityGroups. | `bool` | `false` | no |
 | <a name="input_sg_egress_rules"></a> [sg\_egress\_rules](#input\_sg\_egress\_rules) | Egress rules for the VPC Endpoint SecurityGroup(s). Set to empty list to disable default rules. | <pre>list(object({<br>    description      = string<br>    prefix_list_ids  = list(string)<br>    from_port        = number<br>    to_port          = number<br>    protocol         = string<br>    cidr_blocks      = list(string)<br>    ipv6_cidr_blocks = list(string)<br>    security_groups  = list(string)<br>  }))</pre> | <pre>[<br>  {<br>    "cidr_blocks": [<br>      "0.0.0.0/0"<br>    ],<br>    "description": null,<br>    "from_port": 0,<br>    "ipv6_cidr_blocks": null,<br>    "prefix_list_ids": null,<br>    "protocol": "-1",<br>    "security_groups": null,<br>    "to_port": 0<br>  }<br>]</pre> | no |

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ data "aws_vpc_endpoint_service" "this" {
   service_type = title(each.value.type)
 }
 
-data aws_route_table "gateway_tables" {
+data "aws_route_table" "gateway_tables" {
   for_each = toset(var.subnet_ids)
 
   subnet_id = each.key

--- a/variables.tf
+++ b/variables.tf
@@ -53,7 +53,7 @@ variable "sg_ingress_rules" {
 }
 
 variable "subnet_ids" {
-  description = "Target Subnet IDs for \"Interface\" services. Also used to resolve the `vpc_id` for \"Gateway\" services"
+  description = "Target Subnet IDs for \"Interface\" services. Also used to resolve the `vpc_id` and route_table_ids for \"Gateway\" services"
   type        = list(string)
 }
 


### PR DESCRIPTION
Unfortunately I missed this in #50 and it never bit me until now! The
Interface Endpoints are working great as they take the Subnet IDs as an
argument. But the Gateway endpoints were _never being used_! They
created fine, but they never activated unless Route Table entries were
added outside of the module.

This update activates Gateway Endpoints by default by looking up the
associated Route Tables for each provide Subnet. It then instructs AWS
to insert Routes into each Table.

---

Notes on CI/tests: I was unable to run local tests. I'm hoping the CI tests kick off when the PR opens.

```
❯ make terraform/pytest PYTEST_ARGS="-v --nomock"
[bootstrap]: Clone of tardigrade-ci is up-to-date, skipping auto-init
make[1]: *** No rule to make target 'tftest/install'.  Stop.
make: *** [/Users/..../terraform-aws-tardigrade-vpc-endpoints/tardigrade-ci/Makefile:93: guard/python_pkg/tftest] Error 2
```